### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		</repository>
 		<repository>
 			<id>clojars.org</id>
-			<url>http://clojars.org/repo</url>
+			<url>https://clojars.org/repo</url>
 		</repository>
 	</repositories>
 </project>

--- a/ui/karma-test.sh
+++ b/ui/karma-test.sh
@@ -3,7 +3,7 @@
 BASE_DIR=.
 
 echo ""
-echo "Starting Karma Server (http://karma-runner.github.io)"
+echo "Starting Karma Server (https://karma-runner.github.io)"
 echo "-------------------------------------------------------------------"
 
 karma start karma.conf.js $*


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://karma-runner.github.io migrated to:  
  https://karma-runner.github.io ([https](https://karma-runner.github.io) result 200).
* http://clojars.org/repo migrated to:  
  https://clojars.org/repo ([https](https://clojars.org/repo) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance